### PR TITLE
Drop yidas/yii2-bower-asset dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "symfony/stopwatch": "4.2|^5.2",
         "tightenco/collect": "^5.6|^6.0|^7.0|^8.0",
         "yiisoft/yii2": "^2.0.38",
-        "yidas/yii2-bower-asset": "^2.0",
         "symfony/polyfill-php80": "^v1.22"
     },
     "require-dev": {
@@ -55,6 +54,12 @@
     "extra": {
         "bootstrap": "Spatie\\YiiRay\\BootstrapRay"
     },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
+    ],
     "funding": [
         {
             "type": "github",


### PR DESCRIPTION
I think this is more general approach that can be also seen in other yii2 packages like yiisoft/yii2-debug or yiisoft/yii2-queue. 
Related issue #2